### PR TITLE
docs: add syntax highlight for react snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This project also uses [Husky](https://github.com/typicode/husky) to prevent com
 
 ### React
 
-```sh
+```js
 import styles from '@venice/styles/components/Button.module.scss'
 
 <button className={styles.btn}></button>


### PR DESCRIPTION
Before:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/2853428/82498078-be4a5a00-9ac5-11ea-9ccf-1dd9ebb2fdeb.png">

After:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/2853428/82498125-d326ed80-9ac5-11ea-8ea7-14bd4d00a027.png">
