### PR TITLE
fix: add same space for error msg as input

### DIFF
--- a/packages/styles/components/CheckboxRadio.module.scss
+++ b/packages/styles/components/CheckboxRadio.module.scss
@@ -15,6 +15,7 @@
 .error {
   color: var(--danger-color);
   font: var(--typography-caption-font);
+  margin-top: var(--space-xxs);
 
   svg {
     fill: var(--danger-color);


### PR DESCRIPTION
## Infos

#### What is being delivered?
 add space between the checkbox and error message
#### What impacts?

forms that uses checkboxes

#### Reversal plan

revert commit

#### Evidences

## DoD checklist

- [ ] Related code finished
- [ ] Documentation updated (if exists)
- [ ] Unit tests written and passing
- [ ] Any configuration or build changes documented
- [ ] Project builds without errors
- [ ] Lint errors fixed
