### PR TITLE
fix/re-add-icons

### DIFF
--- a/packages/venice-icons/config.json
+++ b/packages/venice-icons/config.json
@@ -87,7 +87,7 @@
     {
       "uid": "5d73628bc1aa2d5a8d6c92216d7fb52a",
       "css": "arrow-right",
-      "code": 59396,
+      "code": 59141,
       "src": "custom_icons",
       "selected": true,
       "svg": {
@@ -847,9 +847,27 @@
       "search": ["close"]
     },
     {
+      "uid": "e4ad679e06a7c307b31e97e7ce88962e",
+      "css": "shipping",
+      "code": 59408,
+      "src": "custom_icons",
+      "selected": true,
+      "svg": {
+        "path": "M833.3 333.3H708.3V166.7H125C79.2 166.7 41.7 204.2 41.7 250V708.3H125C125 777.5 180.8 833.3 250 833.3 319.2 833.3 375 777.5 375 708.3H625C625 777.5 680.8 833.3 750 833.3 819.2 833.3 875 777.5 875 708.3H958.3V500L833.3 333.3ZM812.5 395.8L894.2 500H708.3V395.8H812.5ZM208.3 708.3C208.3 731.3 227.1 750 250 750 272.9 750 291.7 731.3 291.7 708.3 291.7 685.4 272.9 666.7 250 666.7 227.1 666.7 208.3 685.4 208.3 708.3ZM342.5 625C319.6 599.6 287.1 583.3 250 583.3 212.9 583.3 180.4 599.6 157.5 625H125V250H625V625H342.5ZM708.3 708.3C708.3 731.3 727.1 750 750 750 772.9 750 791.7 731.3 791.7 708.3 791.7 685.4 772.9 666.7 750 666.7 727.1 666.7 708.3 685.4 708.3 708.3Z",
+        "width": 1000
+      },
+      "search": ["shipping"]
+    },
+    {
+      "uid": "e82cedfa1d5f15b00c5a81c9bd731ea2",
+      "css": "info-circled",
+      "code": 59396,
+      "src": "fontawesome"
+    },
+    {
       "uid": "582028fa145ebfecfa559b2fd498c6e2",
       "css": "thin-phone",
-      "code": 59408,
+      "code": 59409,
       "src": "custom_icons",
       "selected": true,
       "svg": {
@@ -861,7 +879,7 @@
     {
       "uid": "4e1af475ad992723e0eaa9e364abf8bb",
       "css": "thin-smartphone",
-      "code": 59409,
+      "code": 59410,
       "src": "custom_icons",
       "selected": true,
       "svg": {
@@ -873,7 +891,7 @@
     {
       "uid": "fbb2425a6db96efca2c8aabb36a7ca88",
       "css": "thin-wifi",
-      "code": 59410,
+      "code": 59411,
       "src": "custom_icons",
       "selected": true,
       "svg": {


### PR DESCRIPTION
## Infos


#### What is being delivered?

Re-added icons that was strangely removed. The icons was added in the following PR's:

#169 
#171 

#### What impacts?

N/A

#### Reversal plan

Revert merge

#### Evidences

![image](https://user-images.githubusercontent.com/9122877/103214354-f3861880-48ee-11eb-8489-4953e2e108fc.png)

## DoD checklist

- [ ] Related code finished
- [ ] Documentation updated (if exists)
- [ ] Unit tests written and passing
- [ ] Any configuration or build changes documented
- [ ] Project builds without errors
- [ ] Lint errors fixed
- [ ] Test a lib's generated build inside projects **!important**
- [ ] Update icon files (woff, woff2 and etc) from projects (if necessary).
