### PR TITLE
feat/chore: add prefix to classes on some components

### DIFF
--- a/packages/react-ds/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/packages/react-ds/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -8,18 +8,18 @@ import { Breadcrumb } from './Breadcrumb'
 describe('<Breadcrumb />', () => {
   it('should have "breadcrumb" classname when render', () => {
     const { container } = render(<Breadcrumb>Default</Breadcrumb>)
-    expect(container.firstChild).toHaveClass('breadcrumb')
+    expect(container.firstChild).toHaveClass('JSMBreadcrumb')
   })
 
   it('should have "default" classname when "color prop" is "default"', () => {
     const { container } = render(<Breadcrumb>Default</Breadcrumb>)
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMBreadcrumb--default')
   })
 
   it('should have "contrast" classname when "color prop" is "contrast"', () => {
     const { container } = render(
       <Breadcrumb color="contrast">Contrast</Breadcrumb>
     )
-    expect(container.firstChild).toHaveClass('contrast')
+    expect(container.firstChild).toHaveClass('JSMBreadcrumb--contrast')
   })
 })

--- a/packages/react-ds/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react-ds/src/components/Breadcrumb/Breadcrumb.tsx
@@ -20,7 +20,11 @@ export const Breadcrumb: React.FunctionComponent<IBreadcrumbProps> = ({
 }) => {
   return (
     <nav
-      className={classNames(styles.breadcrumb, styles[color], className)}
+      className={classNames(
+        styles.JSMBreadcrumb,
+        styles[`JSMBreadcrumb--${color}`],
+        className
+      )}
       aria-label="breadcrumb"
       {...rest}
     >

--- a/packages/react-ds/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-ds/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -8,7 +8,7 @@ export const BreadcrumbItem: React.FunctionComponent<React.HTMLProps<
   HTMLDivElement
 >> = ({ children, className = '', ...rest }) => {
   return (
-    <div className={classNames(styles.breadcrumbItem, className)} {...rest}>
+    <div className={classNames(styles.JSMBreadcrumbItem, className)} {...rest}>
       {children}
     </div>
   )

--- a/packages/react-ds/src/components/Button/index.spec.tsx
+++ b/packages/react-ds/src/components/Button/index.spec.tsx
@@ -7,92 +7,92 @@ import '@testing-library/jest-dom'
 import { Button } from '.'
 
 describe('<Button />', () => {
-  it('should have "default" classname when "color prop" is empty', () => {
+  it('should have "JSMButton--default" classname when "color prop" is empty', () => {
     const { container } = render(<Button>Send</Button>)
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMButton--default')
   })
 
   it('should have "default" classname when "color prop" is "default"', () => {
     const { container } = render(<Button color="default">Send</Button>)
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMButton--default')
   })
 
   it('should have "primary" classname when "color prop" is "primary"', () => {
     const { container } = render(<Button color="primary">Send</Button>)
-    expect(container.firstChild).toHaveClass('primary')
+    expect(container.firstChild).toHaveClass('JSMButton--primary')
   })
 
   it('should have "secondary" classname when "color prop" is "secondary"', () => {
     const { container } = render(<Button color="secondary">Send</Button>)
-    expect(container.firstChild).toHaveClass('secondary')
+    expect(container.firstChild).toHaveClass('JSMButton--secondary')
   })
 
   it('should have "filled" classname when "variant prop" is empty', () => {
     const { container } = render(<Button>Send</Button>)
-    expect(container.firstChild).toHaveClass('filled')
+    expect(container.firstChild).toHaveClass('JSMButton--filled')
   })
 
   it('should have "filled" classname when "variant prop" is "filled"', () => {
     const { container } = render(<Button variant="filled">Send</Button>)
-    expect(container.firstChild).toHaveClass('filled')
+    expect(container.firstChild).toHaveClass('JSMButton--filled')
   })
 
   it('should have "outlined" classname when "variant prop" is "outlined"', () => {
     const { container } = render(<Button variant="outlined">Send</Button>)
-    expect(container.firstChild).toHaveClass('outlined')
+    expect(container.firstChild).toHaveClass('JSMButton--outlined')
   })
 
   it('should have "text" classname when "variant prop" is "text"', () => {
     const { container } = render(<Button variant="text">Send</Button>)
-    expect(container.firstChild).toHaveClass('text')
+    expect(container.firstChild).toHaveClass('JSMButton--text')
   })
 
   it('should have "large" classname when "size prop" is empty', () => {
     const { container } = render(<Button>Send</Button>)
-    expect(container.firstChild).toHaveClass('large')
+    expect(container.firstChild).toHaveClass('JSMButton--large')
   })
 
   it('should have "large" classname when "size prop" is "large"', () => {
     const { container } = render(<Button size="large">Send</Button>)
-    expect(container.firstChild).toHaveClass('large')
+    expect(container.firstChild).toHaveClass('JSMButton--large')
   })
 
   it('should have "medium" classname when "size prop" is "medium"', () => {
     const { container } = render(<Button size="medium">Send</Button>)
-    expect(container.firstChild).toHaveClass('medium')
+    expect(container.firstChild).toHaveClass('JSMButton--medium')
   })
 
   it('should have "small" classname when "size prop" is "small"', () => {
     const { container } = render(<Button size="small">Send</Button>)
-    expect(container.firstChild).toHaveClass('small')
+    expect(container.firstChild).toHaveClass('JSMButton--small')
   })
 
   it('should have "round-square" classname when "shape prop" is empty', () => {
     const { container } = render(<Button>Send</Button>)
-    expect(container.firstChild).toHaveClass('round-square')
+    expect(container.firstChild).toHaveClass('JSMButton--round-square')
   })
 
   it('should have "round-square" classname when "shape prop" is "round-square"', () => {
     const { container } = render(<Button shape="round-square">Send</Button>)
-    expect(container.firstChild).toHaveClass('round-square')
+    expect(container.firstChild).toHaveClass('JSMButton--round-square')
   })
 
   it('should have "circle" classname when "shape prop" is "circle"', () => {
     const { container } = render(<Button shape="circle">Send</Button>)
-    expect(container.firstChild).toHaveClass('circle')
+    expect(container.firstChild).toHaveClass('JSMButton--circle')
   })
 
   it('should have "startIcon" element when has "startIcon prop"', () => {
     const { container } = render(<Button startIcon="←">Back</Button>)
     expect(container.firstChild.firstChild).toContainHTML(
-      `<span class="startIcon">←</span>`
+      `<span class="JSMButtonStartIcon">←</span>`
     )
   })
 
   it('should have "endIcon" element when has "endIcon prop"', () => {
     const { container } = render(<Button endIcon="→">Back</Button>)
     expect(container.firstChild.lastChild).toContainHTML(
-      `<span class="endIcon">→</span>`
+      `<span class="JSMButtonEndIcon">→</span>`
     )
   })
 
@@ -108,7 +108,7 @@ describe('<Button />', () => {
 
   it('should have "isLoading" classname when has "isLoading prop"', () => {
     const { container } = render(<Button isLoading={true}>Loading</Button>)
-    expect(container.firstChild).toHaveClass('isLoading')
+    expect(container.firstChild).toHaveClass('JSMButton--isLoading')
   })
 
   it('should have "Spinner" component when has "isLoading prop"', () => {

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -52,8 +52,8 @@ export const Button: React.FunctionComponent<IButtonProps> = ({
         }
         className={classNames(
           styles.JSMButton,
-          styles[color],
-          styles[variant],
+          styles[`JSMButton--${color}`],
+          styles[`JSMButton--${variant}`],
           styles[size],
           styles[shape],
           {

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -51,7 +51,7 @@ export const Button: React.FunctionComponent<IButtonProps> = ({
           !isLoading && onClick(e)
         }
         className={classNames(
-          styles.button,
+          styles.JSMButton,
           styles[color],
           styles[variant],
           styles[size],
@@ -70,9 +70,13 @@ export const Button: React.FunctionComponent<IButtonProps> = ({
           />
         )}
         <>
-          {startIcon && <span className={styles.startIcon}>{startIcon}</span>}
-          <span className={styles.children}>{children}</span>
-          {endIcon && <span className={styles.endIcon}>{endIcon}</span>}
+          {startIcon && (
+            <span className={styles.JSMButtonStartIcon}>{startIcon}</span>
+          )}
+          <span className={styles.JSMButtonChildren}>{children}</span>
+          {endIcon && (
+            <span className={styles.JSMButtonEndIcon}>{endIcon}</span>
+          )}
         </>
       </ButtonComponent>
     </>

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -54,11 +54,11 @@ export const Button: React.FunctionComponent<IButtonProps> = ({
           styles.JSMButton,
           styles[`JSMButton--${color}`],
           styles[`JSMButton--${variant}`],
-          styles[size],
-          styles[shape],
+          styles[`JSMButton--${size}`],
+          styles[`JSMButton--${shape}`],
           {
             [styles['JSMButton--isLoading']]: isLoading,
-            [styles.bold]: bold,
+            [styles['JSMButton--bold']]: bold,
           },
           className
         )}

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -56,7 +56,10 @@ export const Button: React.FunctionComponent<IButtonProps> = ({
           styles[variant],
           styles[size],
           styles[shape],
-          { [styles.isLoading]: isLoading, [styles.bold]: bold },
+          {
+            [styles['JSMButton--isLoading']]: isLoading,
+            [styles.bold]: bold,
+          },
           className
         )}
         {...(href && { href })}

--- a/packages/react-ds/src/components/Spinner/index.spec.tsx
+++ b/packages/react-ds/src/components/Spinner/index.spec.tsx
@@ -9,22 +9,22 @@ import { Spinner } from '.'
 describe('<Spinner />', () => {
   it('should have "default" classname when prop color is empty', () => {
     const { container } = render(<Spinner></Spinner>)
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMSpinner--default')
   })
 
   it('should have "default" classname when prop color is "default"', () => {
     const { container } = render(<Spinner color="default"></Spinner>)
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMSpinner--default')
   })
 
   it('should have "primary" classname when prop color is "primary"', () => {
     const { container } = render(<Spinner color="primary"></Spinner>)
-    expect(container.firstChild).toHaveClass('primary')
+    expect(container.firstChild).toHaveClass('JSMSpinner--primary')
   })
 
   it('should have "secondary" classname when prop color is "secondary"', () => {
     const { container } = render(<Spinner color="secondary"></Spinner>)
-    expect(container.firstChild).toHaveClass('secondary')
+    expect(container.firstChild).toHaveClass('JSMSpinner--secondary')
   })
 
   it('should have 36px as a default size', () => {

--- a/packages/react-ds/src/components/Spinner/index.tsx
+++ b/packages/react-ds/src/components/Spinner/index.tsx
@@ -18,7 +18,11 @@ export const Spinner = ({
 }: ISpinnerProps) => {
   return (
     <svg
-      className={classNames(styles.spinner, styles[color], className)}
+      className={classNames(
+        styles.JSMSpinner,
+        styles[`JSMSpinner--${color}`],
+        className
+      )}
       style={{
         fontSize: size,
         height: size,
@@ -30,9 +34,7 @@ export const Spinner = ({
       {...rest}
     >
       <circle
-        className={`
-          ${styles.circle}
-        `}
+        className={styles[`JSMSpinner--circle`]}
         fill="none"
         strokeWidth="6"
         strokeLinecap="round"

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -1,0 +1,23 @@
+# Styles
+
+## About component's classes prefix
+
+You should add a prefix before classes of all component to avoid conflict with another libraries or classes.
+
+We are using CSS Modules but if the project that import Venice are using some global styles with the same class name, for example `.primary` it will have be a lot of conflict problems.
+
+So to start a `<button>` component inside Venice, we are using:
+
+```scss
+.JSMButton {
+}
+```
+
+And we should use BEM notation to add some customizations, as:
+
+```scss
+.JSMButton {
+  &--primary {
+  }
+}
+```

--- a/packages/styles/components/Breadcrumb.module.scss
+++ b/packages/styles/components/Breadcrumb.module.scss
@@ -1,10 +1,30 @@
 @import '~@venice/styles/core';
 
-.breadcrumb {
+.JSMBreadcrumb {
   display: flex;
+
+  &--default {
+    .JSMBreadcrumbItem {
+      color: var(--text-color);
+
+      :root & > * {
+        color: var(--text-color);
+      }
+    }
+  }
+
+  &--contrast {
+    .JSMBreadcrumbItem {
+      color: var(--white);
+
+      :root & > * {
+        color: var(--white);
+      }
+    }
+  }
 }
 
-.breadcrumbItem {
+.JSMBreadcrumbItem {
   display: inline-block;
   font: var(--typography-body-font);
   line-height: var(--typography-body-letter);
@@ -38,26 +58,6 @@
       &:hover {
         text-decoration: none;
       }
-    }
-  }
-}
-
-.default {
-  .breadcrumbItem {
-    color: var(--text-color);
-
-    :root & > * {
-      color: var(--text-color);
-    }
-  }
-}
-
-.contrast {
-  .breadcrumbItem {
-    color: var(--white);
-
-    :root & > * {
-      color: var(--white);
     }
   }
 }

--- a/packages/styles/components/Button.module.scss
+++ b/packages/styles/components/Button.module.scss
@@ -75,15 +75,20 @@
       color: var(--disabled-color-contrast);
     }
   }
-}
 
-.isLoading {
-  cursor: default;
+  &--isLoading {
+    cursor: default;
 
-  .JSMButtonChildren,
-  .JSMButtonStartIcon,
-  .JSMButtonEndIcon {
-    opacity: 0;
+    .JSMButtonChildren,
+    .JSMButtonStartIcon,
+    .JSMButtonEndIcon {
+      opacity: 0;
+    }
+  }
+
+  .loading {
+    position: absolute;
+    z-index: var(--zindex-1);
   }
 }
 
@@ -91,7 +96,7 @@
   &.text {
     color: var(--default-color);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--default-color-lighten);
         opacity: 0.1;
@@ -103,7 +108,7 @@
     border-color: var(--default-color);
     color: var(--default-color);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--default-color-lighten);
         opacity: 0.1;
@@ -115,7 +120,7 @@
     background-color: var(--default-color);
     color: var(--default-color-contrast);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--default-color-lighten);
         opacity: 1;
@@ -128,7 +133,7 @@
   &.text {
     color: var(--primary-color);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--primary-color-lighten);
         opacity: 0.1;
@@ -140,7 +145,7 @@
     border-color: var(--primary-color);
     color: var(--primary-color);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--primary-color-lighten);
         opacity: 0.1;
@@ -152,7 +157,7 @@
     background-color: var(--primary-color);
     color: var(--primary-color-contrast);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--primary-color-lighten);
         opacity: 1;
@@ -165,7 +170,7 @@
   &.text {
     color: var(--secondary-color);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--secondary-color-lighten);
         opacity: 0.1;
@@ -177,7 +182,7 @@
     border-color: var(--secondary-color);
     color: var(--secondary-color);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--secondary-color-lighten);
         opacity: 0.1;
@@ -189,7 +194,7 @@
     background-color: var(--secondary-color);
     color: var(--secondary-color-contrast);
 
-    &:not([disabled]):not(.isLoading):hover {
+    &:not([disabled]):not(.JSMButton--isLoading):hover {
       &::before {
         background-color: var(--secondary-color-lighten);
         opacity: 1;
@@ -248,11 +253,6 @@
   &.large {
     width: var(--space-lg);
   }
-}
-
-.loading {
-  position: absolute;
-  z-index: var(--zindex-1);
 }
 
 .bold {

--- a/packages/styles/components/Button.module.scss
+++ b/packages/styles/components/Button.module.scss
@@ -61,16 +61,16 @@
   &[disabled] {
     cursor: default;
 
-    &.text {
+    &.JSMButton--text {
       color: var(--disabled-color);
     }
 
-    &.outlined {
+    &.JSMButton--outlined {
       border-color: var(--disabled-color);
       color: var(--disabled-color);
     }
 
-    &.filled {
+    &.JSMButton--filled {
       background-color: var(--disabled-color);
       color: var(--disabled-color-contrast);
     }
@@ -86,120 +86,120 @@
     }
   }
 
+  &--default {
+    &.JSMButton--text {
+      color: var(--default-color);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--default-color-lighten);
+          opacity: 0.1;
+        }
+      }
+    }
+
+    &.JSMButton--outlined {
+      border-color: var(--default-color);
+      color: var(--default-color);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--default-color-lighten);
+          opacity: 0.1;
+        }
+      }
+    }
+
+    &.JSMButton--filled {
+      background-color: var(--default-color);
+      color: var(--default-color-contrast);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--default-color-lighten);
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  &--primary {
+    &.JSMButton--text {
+      color: var(--primary-color);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--primary-color-lighten);
+          opacity: 0.1;
+        }
+      }
+    }
+
+    &.JSMButton--outlined {
+      border-color: var(--primary-color);
+      color: var(--primary-color);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--primary-color-lighten);
+          opacity: 0.1;
+        }
+      }
+    }
+
+    &.JSMButton--filled {
+      background-color: var(--primary-color);
+      color: var(--primary-color-contrast);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--primary-color-lighten);
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  &--secondary {
+    &.JSMButton--text {
+      color: var(--secondary-color);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--secondary-color-lighten);
+          opacity: 0.1;
+        }
+      }
+    }
+
+    &.JSMButton--outlined {
+      border-color: var(--secondary-color);
+      color: var(--secondary-color);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--secondary-color-lighten);
+          opacity: 0.1;
+        }
+      }
+    }
+
+    &.JSMButton--filled {
+      background-color: var(--secondary-color);
+      color: var(--secondary-color-contrast);
+
+      &:not([disabled]):not(.JSMButton--isLoading):hover {
+        &::before {
+          background-color: var(--secondary-color-lighten);
+          opacity: 1;
+        }
+      }
+    }
+  }
+
   .loading {
     position: absolute;
     z-index: var(--zindex-1);
-  }
-}
-
-.default {
-  &.text {
-    color: var(--default-color);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--default-color-lighten);
-        opacity: 0.1;
-      }
-    }
-  }
-
-  &.outlined {
-    border-color: var(--default-color);
-    color: var(--default-color);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--default-color-lighten);
-        opacity: 0.1;
-      }
-    }
-  }
-
-  &.filled {
-    background-color: var(--default-color);
-    color: var(--default-color-contrast);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--default-color-lighten);
-        opacity: 1;
-      }
-    }
-  }
-}
-
-.primary {
-  &.text {
-    color: var(--primary-color);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--primary-color-lighten);
-        opacity: 0.1;
-      }
-    }
-  }
-
-  &.outlined {
-    border-color: var(--primary-color);
-    color: var(--primary-color);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--primary-color-lighten);
-        opacity: 0.1;
-      }
-    }
-  }
-
-  &.filled {
-    background-color: var(--primary-color);
-    color: var(--primary-color-contrast);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--primary-color-lighten);
-        opacity: 1;
-      }
-    }
-  }
-}
-
-.secondary {
-  &.text {
-    color: var(--secondary-color);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--secondary-color-lighten);
-        opacity: 0.1;
-      }
-    }
-  }
-
-  &.outlined {
-    border-color: var(--secondary-color);
-    color: var(--secondary-color);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--secondary-color-lighten);
-        opacity: 0.1;
-      }
-    }
-  }
-
-  &.filled {
-    background-color: var(--secondary-color);
-    color: var(--secondary-color-contrast);
-
-    &:not([disabled]):not(.JSMButton--isLoading):hover {
-      &::before {
-        background-color: var(--secondary-color-lighten);
-        opacity: 1;
-      }
-    }
   }
 }
 

--- a/packages/styles/components/Button.module.scss
+++ b/packages/styles/components/Button.module.scss
@@ -1,6 +1,6 @@
 @import '~@venice/styles/core';
 
-.button {
+.JSMButton {
   align-items: center;
   background-color: transparent;
   border: 1px solid transparent;
@@ -31,6 +31,33 @@
     transition-property: opacity;
   }
 
+  &Children {
+    display: inherit;
+    position: relative;
+
+    img {
+      max-width: none;
+    }
+  }
+
+  &StartIcon {
+    display: inline-block;
+    position: relative;
+
+    &:not(:empty) {
+      margin-right: var(--space-xs);
+    }
+  }
+
+  &EndIcon {
+    display: inline-block;
+    position: relative;
+
+    &:not(:empty) {
+      margin-left: var(--space-xs);
+    }
+  }
+
   &[disabled] {
     cursor: default;
 
@@ -50,39 +77,12 @@
   }
 }
 
-.children {
-  display: inherit;
-  position: relative;
-
-  img {
-    max-width: none;
-  }
-}
-
-.startIcon {
-  display: inline-block;
-  position: relative;
-
-  &:not(:empty) {
-    margin-right: var(--space-xs);
-  }
-}
-
-.endIcon {
-  display: inline-block;
-  position: relative;
-
-  &:not(:empty) {
-    margin-left: var(--space-xs);
-  }
-}
-
 .isLoading {
   cursor: default;
 
-  .children,
-  .startIcon,
-  .endIcon {
+  .JSMButtonChildren,
+  .JSMButtonStartIcon,
+  .JSMButtonEndIcon {
     opacity: 0;
   }
 }
@@ -203,7 +203,7 @@
   padding-left: var(--space-sm);
   padding-right: var(--space-sm);
 
-  .children {
+  .JSMButtonChildren {
     font-size: 0.8em;
   }
 }
@@ -213,7 +213,7 @@
   padding-left: var(--space);
   padding-right: var(--space);
 
-  .children {
+  .JSMButtonChildren {
     font-size: 0.9em;
   }
 }
@@ -223,7 +223,7 @@
   padding-left: var(--space);
   padding-right: var(--space);
 
-  .children {
+  .JSMButtonChildren {
     font-size: 1em;
   }
 }

--- a/packages/styles/components/Button.module.scss
+++ b/packages/styles/components/Button.module.scss
@@ -197,64 +197,64 @@
     }
   }
 
-  .loading {
-    position: absolute;
-    z-index: var(--zindex-1);
-  }
-}
-
-.small {
-  height: var(--space-md);
-  padding-left: var(--space-sm);
-  padding-right: var(--space-sm);
-
-  .JSMButtonChildren {
-    font-size: 0.8em;
-  }
-}
-
-.medium {
-  height: 40px;
-  padding-left: var(--space);
-  padding-right: var(--space);
-
-  .JSMButtonChildren {
-    font-size: 0.9em;
-  }
-}
-
-.large {
-  height: var(--space-lg);
-  padding-left: var(--space);
-  padding-right: var(--space);
-
-  .JSMButtonChildren {
-    font-size: 1em;
-  }
-}
-
-.round-square {
-  min-width: var(--space-xlg);
-}
-
-.circle {
-  border-radius: 50%;
-
-  &.small {
-    width: var(--space-md);
-  }
-
-  &.medium {
+  &--small {
+    height: var(--space-md);
     padding-left: var(--space-sm);
     padding-right: var(--space-sm);
-    width: 40px;
+
+    .JSMButtonChildren {
+      font-size: 0.8em;
+    }
   }
 
-  &.large {
-    width: var(--space-lg);
+  &--medium {
+    height: 40px;
+    padding-left: var(--space);
+    padding-right: var(--space);
+
+    .JSMButtonChildren {
+      font-size: 0.9em;
+    }
+  }
+
+  &--large {
+    height: var(--space-lg);
+    padding-left: var(--space);
+    padding-right: var(--space);
+
+    .JSMButtonChildren {
+      font-size: 1em;
+    }
+  }
+
+  &--circle {
+    border-radius: 50%;
+
+    &.JSMButton--small {
+      width: var(--space-md);
+    }
+
+    &.JSMButton--medium {
+      padding-left: var(--space-sm);
+      padding-right: var(--space-sm);
+      width: 40px;
+    }
+
+    &.JSMButton--large {
+      width: var(--space-lg);
+    }
+  }
+
+  &--bold {
+    font-weight: bold;
+  }
+
+  &--round-square {
+    min-width: var(--space-xlg);
   }
 }
 
-.bold {
-  font-weight: bold;
+.loading {
+  position: absolute;
+  z-index: var(--zindex-1);
 }

--- a/packages/styles/components/Spinner.module.scss
+++ b/packages/styles/components/Spinner.module.scss
@@ -4,41 +4,41 @@ $rotation: 270;
 $dashoffset: 180;
 $animation-time: 1.2s;
 
-.spinner {
+.JSMSpinner {
   animation: rotation $animation-time linear infinite;
-}
 
-.circle {
-  animation: turn $animation-time ease-in-out infinite;
-  stroke-dasharray: $dashoffset;
-  stroke-dashoffset: 0;
-  stroke-linecap: round;
-  stroke-width: 6;
-  transform-origin: center;
-}
+  &--circle {
+    animation: turn $animation-time ease-in-out infinite;
+    stroke-dasharray: $dashoffset;
+    stroke-dashoffset: 0;
+    stroke-linecap: round;
+    stroke-width: 6;
+    transform-origin: center;
+  }
 
-.default {
-  stroke: var(--default-color);
-}
+  &--default {
+    stroke: var(--default-color);
+  }
 
-.default-contrast {
-  stroke: var(--default-color-contrast);
-}
+  &--default-contrast {
+    stroke: var(--default-color-contrast);
+  }
 
-.primary {
-  stroke: var(--primary-color);
-}
+  &--primary {
+    stroke: var(--primary-color);
+  }
 
-.primary-contrast {
-  stroke: var(--primary-color-contrast);
-}
+  &--primary-contrast {
+    stroke: var(--primary-color-contrast);
+  }
 
-.secondary {
-  stroke: var(--secondary-color);
-}
+  &--secondary {
+    stroke: var(--secondary-color);
+  }
 
-.secondary-contrast {
-  stroke: var(--secondary-color-contrast);
+  &--secondary-contrast {
+    stroke: var(--secondary-color-contrast);
+  }
 }
 
 @keyframes rotation {

--- a/packages/vue-ds/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/packages/vue-ds/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -5,7 +5,7 @@ import Breadcrumb from './Breadcrumb.vue'
 describe('<Breadcrumb />', () => {
   it('should have "Breadcrumb" classname when render', () => {
     const wrapper = mount(Breadcrumb)
-    expect(wrapper.classes()).toContain('breadcrumb')
+    expect(wrapper.classes()).toContain('JSMBreadcrumb')
   })
 
   it('should have "default" classname when "color prop" is "default"', () => {
@@ -14,7 +14,7 @@ describe('<Breadcrumb />', () => {
         color: 'default',
       },
     })
-    expect(wrapper.classes()).toContain('default')
+    expect(wrapper.classes()).toContain('JSMBreadcrumb--default')
   })
 
   it('should have "contrast" classname when "color prop" is "contrast"', () => {
@@ -23,6 +23,6 @@ describe('<Breadcrumb />', () => {
         color: 'contrast',
       },
     })
-    expect(wrapper.classes()).toContain('contrast')
+    expect(wrapper.classes()).toContain('JSMBreadcrumb--contrast')
   })
 })

--- a/packages/vue-ds/src/components/Breadcrumb/Breadcrumb.vue
+++ b/packages/vue-ds/src/components/Breadcrumb/Breadcrumb.vue
@@ -13,7 +13,7 @@ export default class Breadcrumb extends Vue {
   @Prop({ default: 'default' }) color!: IBreadcrumb['color']
 
   get breadcrumbClass() {
-    return ['breadcrumb', this.color]
+    return ['JSMBreadcrumb', `JSMBreadcrumb--${this.color}`]
   }
 }
 </script>

--- a/packages/vue-ds/src/components/Breadcrumb/BreadcrumbItem.vue
+++ b/packages/vue-ds/src/components/Breadcrumb/BreadcrumbItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="breadcrumbItem">
+  <div class="JSMBreadcrumbItem">
     <slot />
   </div>
 </template>

--- a/packages/vue-ds/src/components/Button/Button.spec.tsx
+++ b/packages/vue-ds/src/components/Button/Button.spec.tsx
@@ -7,7 +7,7 @@ import Button from './Button.vue'
 describe('<Button />', () => {
   it('should have "default" classname when "color prop" is empty', () => {
     const wrapper = mount(Button)
-    expect(wrapper.classes()).toContain('default')
+    expect(wrapper.classes()).toContain('JSMButton--default')
   })
 
   it('should have "default" classname when "color prop" is "default"', () => {
@@ -16,7 +16,7 @@ describe('<Button />', () => {
         color: 'default',
       },
     })
-    expect(wrapper.classes()).toContain('default')
+    expect(wrapper.classes()).toContain('JSMButton--default')
   })
 
   it('should have "primary" classname when "color prop" is "primary"', () => {
@@ -25,7 +25,7 @@ describe('<Button />', () => {
         color: 'primary',
       },
     })
-    expect(wrapper.classes()).toContain('primary')
+    expect(wrapper.classes()).toContain('JSMButton--primary')
   })
 
   it('should have "secondary" classname when "color prop" is "secondary"', () => {
@@ -34,12 +34,12 @@ describe('<Button />', () => {
         color: 'secondary',
       },
     })
-    expect(wrapper.classes()).toContain('secondary')
+    expect(wrapper.classes()).toContain('JSMButton--secondary')
   })
 
   it('should have "filled" classname when "variant prop" is empty', () => {
     const wrapper = mount(Button)
-    expect(wrapper.classes()).toContain('filled')
+    expect(wrapper.classes()).toContain('JSMButton--filled')
   })
 
   it('should have "filled" classname when "variant prop" propsData is "filled"', () => {
@@ -48,7 +48,7 @@ describe('<Button />', () => {
         variant: 'filled',
       },
     })
-    expect(wrapper.classes()).toContain('filled')
+    expect(wrapper.classes()).toContain('JSMButton--filled')
   })
 
   it('should have "outlined" classname when "variant prop" propsData is "outlined"', () => {
@@ -57,7 +57,7 @@ describe('<Button />', () => {
         variant: 'outlined',
       },
     })
-    expect(wrapper.classes()).toContain('outlined')
+    expect(wrapper.classes()).toContain('JSMButton--outlined')
   })
 
   it('should have "text" classname when "variant prop" propsData is "text"', () => {
@@ -66,12 +66,12 @@ describe('<Button />', () => {
         variant: 'text',
       },
     })
-    expect(wrapper.classes()).toContain('text')
+    expect(wrapper.classes()).toContain('JSMButton--text')
   })
 
   it('should have "large" classname when "size prop" is empty', () => {
     const wrapper = mount(Button)
-    expect(wrapper.classes()).toContain('large')
+    expect(wrapper.classes()).toContain('JSMButton--large')
   })
 
   it('should have "large" classname when "size prop" is "large"', () => {
@@ -80,7 +80,7 @@ describe('<Button />', () => {
         size: 'large',
       },
     })
-    expect(wrapper.classes()).toContain('large')
+    expect(wrapper.classes()).toContain('JSMButton--large')
   })
 
   it('should have "medium" classname when "size prop" is "medium"', () => {
@@ -89,7 +89,7 @@ describe('<Button />', () => {
         size: 'medium',
       },
     })
-    expect(wrapper.classes()).toContain('medium')
+    expect(wrapper.classes()).toContain('JSMButton--medium')
   })
 
   it('should have "small" classname when "size prop" is "small"', () => {
@@ -98,12 +98,12 @@ describe('<Button />', () => {
         size: 'small',
       },
     })
-    expect(wrapper.classes()).toContain('small')
+    expect(wrapper.classes()).toContain('JSMButton--small')
   })
 
   it('should have "round-square" classname when "shape prop" is empty', () => {
     const wrapper = mount(Button)
-    expect(wrapper.classes()).toContain('round-square')
+    expect(wrapper.classes()).toContain('JSMButton--round-square')
   })
 
   it('should have "round-square" classname when "shape prop" is "round-square"', () => {
@@ -112,7 +112,7 @@ describe('<Button />', () => {
         shape: 'round-square',
       },
     })
-    expect(wrapper.classes()).toContain('round-square')
+    expect(wrapper.classes()).toContain('JSMButton--round-square')
   })
 
   it('should have "circle" classname when "shape prop" is "circle"', () => {
@@ -121,7 +121,7 @@ describe('<Button />', () => {
         shape: 'circle',
       },
     })
-    expect(wrapper.classes()).toContain('circle')
+    expect(wrapper.classes()).toContain('JSMButton--circle')
   })
 
   it('should have "startIcon" element when has "startIcon prop"', () => {
@@ -130,10 +130,10 @@ describe('<Button />', () => {
         startIcon: '←',
       },
     })
-    const endIcon = wrapper.find('.endIcon')
+    const endIcon = wrapper.find('.JSMButtonEndIcon')
 
-    expect(wrapper.find('.startIcon').html()).toBe(
-      `<span class="startIcon">←</span>`
+    expect(wrapper.find('.JSMButtonStartIcon').html()).toBe(
+      `<span class="JSMButtonStartIcon">←</span>`
     )
     expect(endIcon.exists()).toBeFalsy()
   })
@@ -144,11 +144,11 @@ describe('<Button />', () => {
         endIcon: '→',
       },
     })
-    const startIcon = wrapper.find('.startIcon')
+    const startIcon = wrapper.find('.JSMButtonStartIcon')
 
     expect(startIcon.exists()).toBeFalsy()
-    expect(wrapper.find('.endIcon').html()).toBe(
-      `<span class="endIcon">→</span>`
+    expect(wrapper.find('.JSMButtonEndIcon').html()).toBe(
+      `<span class="JSMButtonEndIcon">→</span>`
     )
   })
 
@@ -172,7 +172,7 @@ describe('<Button />', () => {
         isLoading: true,
       },
     })
-    expect(wrapper.classes()).toContain('isLoading')
+    expect(wrapper.classes()).toContain('JSMButton--isLoading')
   })
 
   it('should have "Spinner" component when has "isLoading prop"', () => {

--- a/packages/vue-ds/src/components/Button/Button.vue
+++ b/packages/vue-ds/src/components/Button/Button.vue
@@ -50,8 +50,8 @@ export default class Button extends Vue {
   get buttonClass() {
     return [
       'JSMButton',
-      this.color,
-      this.variant,
+      `JSMButton--${this.color}`,
+      `JSMButton--${this.variant}`,
       this.shape,
       this.size,
       this.isLoading ? 'JSMButton--isLoading' : '',

--- a/packages/vue-ds/src/components/Button/Button.vue
+++ b/packages/vue-ds/src/components/Button/Button.vue
@@ -54,7 +54,7 @@ export default class Button extends Vue {
       this.variant,
       this.shape,
       this.size,
-      this.isLoading ? 'isLoading' : '',
+      this.isLoading ? 'JSMButton--isLoading' : '',
     ]
   }
 

--- a/packages/vue-ds/src/components/Button/Button.vue
+++ b/packages/vue-ds/src/components/Button/Button.vue
@@ -52,8 +52,8 @@ export default class Button extends Vue {
       'JSMButton',
       `JSMButton--${this.color}`,
       `JSMButton--${this.variant}`,
-      this.shape,
-      this.size,
+      `JSMButton--${this.shape}`,
+      `JSMButton--${this.size}`,
       this.isLoading ? 'JSMButton--isLoading' : '',
     ]
   }

--- a/packages/vue-ds/src/components/Button/Button.vue
+++ b/packages/vue-ds/src/components/Button/Button.vue
@@ -13,15 +13,15 @@
       :size="spinnerSize"
       class="loading"
     />
-    <span v-if="$slots.startIcon" class="startIcon">
+    <span v-if="$slots.startIcon" class="JSMButtonStartIcon">
       <!-- @slot To add icon at the beginning -->
       <slot name="startIcon" />
     </span>
-    <span class="children">
+    <span class="JSMButtonChildren">
       <!-- @slot To add something, like a text -->
       <slot />
     </span>
-    <span v-if="$slots.endIcon" class="endIcon">
+    <span v-if="$slots.endIcon" class="JSMButtonEndIcon">
       <!-- @slot To add icon at the end -->
       <slot name="endIcon" />
     </span>
@@ -49,7 +49,7 @@ export default class Button extends Vue {
 
   get buttonClass() {
     return [
-      'button',
+      'JSMButton',
       this.color,
       this.variant,
       this.shape,

--- a/packages/vue-ds/src/components/Spinner/Spinner.spec.tsx
+++ b/packages/vue-ds/src/components/Spinner/Spinner.spec.tsx
@@ -7,7 +7,7 @@ import Spinner from './Spinner.vue'
 describe('<Spinner />', () => {
   it('should have "default" classname when prop color is empty', () => {
     const { container } = render(Spinner)
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMSpinner--default')
   })
 
   it('should have "default" classname when prop color is "default"', () => {
@@ -16,7 +16,7 @@ describe('<Spinner />', () => {
         color: 'default',
       },
     })
-    expect(container.firstChild).toHaveClass('default')
+    expect(container.firstChild).toHaveClass('JSMSpinner--default')
   })
 
   it('should have "primary" classname when prop color is "primary"', () => {
@@ -25,7 +25,7 @@ describe('<Spinner />', () => {
         color: 'primary',
       },
     })
-    expect(container.firstChild).toHaveClass('primary')
+    expect(container.firstChild).toHaveClass('JSMSpinner--primary')
   })
 
   it('should have "secondary" classname when prop color is "secondary"', () => {
@@ -34,7 +34,7 @@ describe('<Spinner />', () => {
         color: 'secondary',
       },
     })
-    expect(container.firstChild).toHaveClass('secondary')
+    expect(container.firstChild).toHaveClass('JSMSpinner--secondary')
   })
 
   it('should have 36px as a default size', () => {

--- a/packages/vue-ds/src/components/Spinner/Spinner.vue
+++ b/packages/vue-ds/src/components/Spinner/Spinner.vue
@@ -1,13 +1,13 @@
 <template>
   <svg
-    :class="['spinner', color]"
+    :class="['JSMSpinner', `JSMSpinner--${color}`]"
     :style="{ height: `${size}px`, width: `${size}px` }"
     role="progressbar"
     aria-busy="true"
     viewBox="0 0 66 66"
   >
     <circle
-      :class="['circle']"
+      :class="['JSMSpinner--circle']"
       fill="none"
       strokeWidth="6"
       strokeLinecap="round"


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/346211397/pulses/1020073033)

#### What is being delivered?

The main idea of this task is add `JSM` prefix and BEM notation to avoid conflicts with some classes or libraries that is using inside project that also use Venice.

#### What impacts?

Adds prefix classes on:

- Breadcrumb
- Button
- Spinner

And change all tests about this components.

#### Reversal plan

Just reverse a branch.
 