### PR TITLE
[chore]: remove icon from input when in error state

### DIFF
--- a/packages/react-ds/src/components/Input/index.tsx
+++ b/packages/react-ds/src/components/Input/index.tsx
@@ -7,8 +7,6 @@ import uniqid from 'uniqid'
 
 import styles from '@venice/styles/components/Field.module.scss'
 
-import Alert from '../Icons/Alert'
-
 const InternalInput = (
   {
     id,
@@ -36,12 +34,7 @@ const InternalInput = (
       )}
       <IMaskInput className={styles.field} id={selfId} {...props} ref={ref} />
       {/* TODO: Replace for alert component */}
-      {error && (
-        <div className={styles.error}>
-          <Alert />
-          {error}
-        </div>
-      )}
+      {error && <div className={styles.error}>{error}</div>}
     </div>
   )
 }


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/346124957/pulses/953910560)

#### What is being delivered?
Due to new design specs based on material UI we need to remove the icon from input error text

#### What impacts?
Input component on error

#### Reversal plan
revert this pr merge and/or roll back on azure

#### Evidences
<img width="1440" alt="Screen Shot 2021-02-25 at 16 51 48" src="https://user-images.githubusercontent.com/4422534/109209661-8fff5680-778a-11eb-9ab7-76cfac2919d8.png">


## DoD checklist

- [x] Related code finished
- [x] Documentation updated (if exists)
~- [ ] Unit tests written and passing~
~- [ ] Any configuration or build changes documented~
- [x] Project builds without errors
~- [ ] Lint errors fixed~
- [x] Test a lib's generated build inside projects **!important**
~- [ ] Update icon files (woff, woff2 and etc) from projects (if necessary).~
