### PR TITLE
fix: add button role link

### DIFF
--- a/packages/react-ds/src/components/Button/index.spec.tsx
+++ b/packages/react-ds/src/components/Button/index.spec.tsx
@@ -97,7 +97,8 @@ describe('<Button />', () => {
   })
 
   it('should be add a href in <a> if it has href', () => {
-    const { container } = render(<Button href="href">Send</Button>)
+    const { container, getByRole } = render(<Button href="href">Send</Button>)
+    expect(getByRole('link', { name: 'Send' })).toBeInTheDocument()
     expect(container.querySelector('a[href="href"]')).toBeInTheDocument()
   })
 

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -45,7 +45,7 @@ export const Button: React.FunctionComponent<IButtonProps> = ({
     <>
       <ButtonComponent
         as={href ? 'a' : 'button'}
-        role={href ? '' : 'button'}
+        role={href ? 'link' : 'button'}
         aria-busy={isLoading}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
           !isLoading && onClick(e)


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Add role “link” in Button component when it has a href

#### What impacts?

- React button component

#### Reversal plan

- Reverse PR

#### Evidences

- N/A

## DoD checklist

- [x] Related code finished
- [ ] Documentation updated (if exists)
- [x] Unit tests written and passing
- [ ] Any configuration or build changes documented
- [x] Project builds without errors
- [x] Lint errors fixed
- [ ] Test a lib's generated build inside projects **!important**
- [ ] Update icon files (woff, woff2 and etc) from projects (if necessary).
