### PR TITLE
feat(react-ds): add type props in ts

### DIFF
--- a/packages/react-ds/src/components/Button/index.spec.tsx
+++ b/packages/react-ds/src/components/Button/index.spec.tsx
@@ -147,4 +147,18 @@ describe('<Button />', () => {
     fireEvent.click(getByText('Loading'))
     expect(onClick).not.toBeCalled()
   })
+
+  it('should be able to submit a form with type submit', () => {
+    const submitMocked = jest.fn()
+
+    const { getByText } = render(
+      <form onSubmit={submitMocked}>
+        <Button type="submit">Submit</Button>
+      </form>
+    )
+
+    fireEvent.submit(getByText('Submit'))
+
+    expect(submitMocked).toHaveBeenCalled()
+  })
 })

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -20,6 +20,8 @@ export interface IButtonProps extends Omit<IButton, 'color'> {
   startIcon?: React.ReactNode | string
   /** React MouseEvent  */
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  /** 'submit' | 'reset' | 'button' | undefined */
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type']
 }
 
 const ButtonComponent: React.FunctionComponent<

--- a/packages/react-ds/src/components/Button/index.tsx
+++ b/packages/react-ds/src/components/Button/index.tsx
@@ -7,7 +7,9 @@ import styles from '@venice/styles/components/Button.module.scss'
 
 import { Spinner } from '../Spinner'
 
-export interface IButtonProps extends Omit<IButton, 'color'> {
+export interface IButtonProps
+  extends Omit<IButton, 'color'>,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** string */
   className?: string
   /**  'default' | 'primary' | 'secondary' | 'white' */
@@ -20,8 +22,6 @@ export interface IButtonProps extends Omit<IButton, 'color'> {
   startIcon?: React.ReactNode | string
   /** React MouseEvent  */
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
-  /** 'submit' | 'reset' | 'button' | undefined */
-  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type']
 }
 
 const ButtonComponent: React.FunctionComponent<


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1417536909/pulses/3790796566)

#### What is being delivered?

- Add prop `type` in `Venice Button` typing

#### What impacts?

- Typing in `Button` of React DS Venice 

#### Reversal plan

- Revert merge

#### Evidences


| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/75763403/211839034-2c43ad69-a660-4eb5-be66-052c5d18f3e1.png) | ![image](https://user-images.githubusercontent.com/75763403/211839096-be7febcc-dade-4b35-9188-f144ee8d8121.png) |





## DoD checklist

- [x] Related code finished
- [x] Documentation updated (if exists)
- [x] Unit tests written and passing
- [ ] Any configuration or build changes documented
- [x] Project builds without errors
- [x] Lint errors fixed
- [ ] Test a lib's generated build inside projects **!important**
- [ ] Update icon files (woff, woff2 and etc) from projects (if necessary).
