### PR TITLE
[MASTER] chore: add backdrop to variables scope

### DIFF
--- a/packages/styles/global/variables.scss
+++ b/packages/styles/global/variables.scss
@@ -1,4 +1,5 @@
-:root {
+:root,
+::backdrop {
   /* Spacings
   * ------------------------- */
   --spacing-xxsmall: 4px;
@@ -14,15 +15,15 @@
   --spacing-giant: 64px;
   --spacing-xgiant: 80px;
 
-    /* Colors
+  /* Colors
   * ------------------------- */
   --color-neutral-dark-1: #000;
-  --color-neutral-regular: #1F2328;
-  --color-neutral-light-1: #464F59;
-  --color-neutral-light-2: #7E8B97;
-  --color-neutral-light-3: #B9BFC6;
-  --color-neutral-light-4: #DEE1E4;
-  --color-neutral-light-5: #F1F3F3;
+  --color-neutral-regular: #1f2328;
+  --color-neutral-light-1: #464f59;
+  --color-neutral-light-2: #7e8b97;
+  --color-neutral-light-3: #b9bfc6;
+  --color-neutral-light-4: #dee1e4;
+  --color-neutral-light-5: #f1f3f3;
   --color-neutral-white: #fff;
   --color-brand-primary-dark-1: #b85000;
   --color-brand-primary-regular: #ed6700;
@@ -44,17 +45,17 @@
   --color-contextual-warning-regular: #ffc900;
   --color-contextual-warning-light-1: #ffda52;
   --color-contextual-warning-light-2: #fff4cc;
-  --color-contextual-info-dark-1: #0A6171;
-  --color-contextual-info-regular: #0D8296;
-  --color-contextual-info-light-1: #10A2BC;
-  --color-contextual-info-light-2: #E3F9FD;
+  --color-contextual-info-dark-1: #0a6171;
+  --color-contextual-info-regular: #0d8296;
+  --color-contextual-info-light-1: #10a2bc;
+  --color-contextual-info-light-2: #e3f9fd;
 
   /* Fonts
   * ------------------------- */
   --font-family: 'Roboto', sans-serif;
   --font-weight-regular: 400;
   --font-weight-bold: 700;
-// This font-weight is deprecated, letting here for backwards compatibility.
+  // This font-weight is deprecated, letting here for backwards compatibility.
   --font-weight-medium: 500;
 
   /* Typography
@@ -97,7 +98,8 @@
   --button-medium-letter: 0.08em;
   --text-caption: var(--font-weight-regular) 12px/20px var(--font-family);
   --text-caption-letter: 0.004em;
-  --text-caption-focused: var(--font-weight-regular) 12px/20px var(--font-family);
+  --text-caption-focused: var(--font-weight-regular) 12px/20px
+    var(--font-family);
   --text-caption-focused-letter: 0.0004em;
   --text-overline: var(--font-weight-regular) 11px/20px var(--font-family);
   --text-overline-letter: 0.014em;
@@ -127,7 +129,7 @@
   --zindex-overlay: 10000;
   --transition-duration: 0.25s;
 
-    /* Old Colors
+  /* Old Colors
   * TODO: Remove it after all color variables are migrated to new color variables
   * ------------------------- */
   --black: #111;
@@ -178,13 +180,17 @@
   --typography-panel-letter: 0;
   --typography-title-font: 500 24px/28px var(--font-family);
   --typography-title-letter: -0.357143px;
-  --typography-subheader-font: var(--font-weight-regular) 20px/24px var(--font-family);
+  --typography-subheader-font: var(--font-weight-regular) 20px/24px
+    var(--font-family);
   --typography-subheader-letter: -0.288572px;
-  --typography-body-font: var(--font-weight-regular) 16px/19px var(--font-family);
+  --typography-body-font: var(--font-weight-regular) 16px/19px
+    var(--font-family);
   --typography-body-letter: -0.228572px;
-  --typography-body2-font: var(--font-weight-regular) 14px/16px var(--font-family);
+  --typography-body2-font: var(--font-weight-regular) 14px/16px
+    var(--font-family);
   --typography-body2-letter: -0.2px;
-  --typography-caption-font: var(--font-weight-regular) 12px/14px var(--font-family);
+  --typography-caption-font: var(--font-weight-regular) 12px/14px
+    var(--font-family);
   --typography-caption-letter: -0.171429px;
   --typography-button-font: 500 16px/19px var(--font-family);
   --typography-button-letter: -0.228572px;
@@ -211,17 +217,21 @@
     --title-giant-letter: 0.025em;
     --title-display: var(--font-weight-bold) 28px/36px var(--font-family);
     --title-display-letter: 0.025em;
-    --title-headline-xxlarge: var(--font-weight-bold) 26px/36px var(--font-family);
+    --title-headline-xxlarge: var(--font-weight-bold) 26px/36px
+      var(--font-family);
     --title-headline-xxlarge-letter: 0.025em;
-    --title-headline-xlarge: var(--font-weight-bold) 25px/32px var(--font-family);
+    --title-headline-xlarge: var(--font-weight-bold) 25px/32px
+      var(--font-family);
     --title-headline-xlarge-letter: 0.025em;
     --title-headline-large: var(--font-weight-bold) 24px/32px var(--font-family);
     --title-headline-large-letter: 0.025em;
-    --title-headline-medium: var(--font-weight-bold) 22px/28px var(--font-family);
+    --title-headline-medium: var(--font-weight-bold) 22px/28px
+      var(--font-family);
     --title-headline-medium-letter: 0.015em;
     --title-headline-small: var(--font-weight-bold) 20px/28px var(--font-family);
     --title-headline-small-letter: 0.015em;
-    --title-headline-xsmall: var(--font-weight-bold) 19px/24px var(--font-family);
+    --title-headline-xsmall: var(--font-weight-bold) 19px/24px
+      var(--font-family);
     --title-headline-xsmall-letter: 0.015em;
     --text-subtitle-large: var(--font-weight-bold) 18px/24px var(--font-family);
     --text-subtitle-large-letter: 0.015em;
@@ -245,7 +255,8 @@
     --button-medium-letter: 0.08em;
     --text-caption: var(--font-weight-regular) 12px/20px var(--font-family);
     --text-caption-letter: 0.004em;
-    --text-caption-focused: var(--font-weight-regular) 12px/20px var(--font-family);
+    --text-caption-focused: var(--font-weight-regular) 12px/20px
+      var(--font-family);
     --text-caption-focused-letter: 0.0004em;
     --text-overline: var(--font-weight-regular) 11px/20px var(--font-family);
     --text-overline-letter: 0.014em;


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

Add backdrop pseudo-element scope in vars, because it has his own scope. It can be read in that [thread](https://fullscreen.spec.whatwg.org/#::backdrop-pseudo-element)

#### What impacts?

Backdrop scope extends the venice variables of root.

#### Reversal plan

Revert to the prev commit in the commit three and remove the remaining code.

#### Evidences

None.

## DoD checklist

- [ ] Related code finished
- [ ] Documentation updated (if exists)
- [ ] Unit tests written and passing
- [ ] Any configuration or build changes documented
- [ ] Project builds without errors
- [ ] Lint errors fixed
- [ ] Test a lib's generated build inside projects **!important**
- [ ] Update icon files (woff, woff2 and etc) from projects (if necessary).
